### PR TITLE
Fix for email domains with no letters

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,6 +158,11 @@ function findEmail(_, atext, label, match) {
     return false
   }
 
+  // Do not link if label does not contain a letter.
+  if (!/[a-z]/i.test(label)) {
+    return false
+  }
+
   return {
     type: 'link',
     title: null,

--- a/test/base.html
+++ b/test/base.html
@@ -53,6 +53,7 @@
 <p><a href="mailto:a@a-b.c">a@a-b.c</a></p>
 <p>Can’t end in an underscore followed by a period: aaa@a.b_.</p>
 <p>Can contain an underscore followed by a period: <a href="mailto:aaa@a.b_.c">aaa@a.b_.c</a></p>
+<p>Can't have a domain with no letters: mdast-util-gfm-autolink-literal@1.0.1</p>
 <h2>Link text should not be expanded</h2>
 <p><a href="http://www.example.com">Visit www.example.com</a> please.</p>
 <p><a href="http://www.example.com">Visit http://www.example.com</a> please.</p>

--- a/test/base.md
+++ b/test/base.md
@@ -108,6 +108,8 @@ Can’t end in an underscore followed by a period: aaa@a.b_.
 
 Can contain an underscore followed by a period: aaa@a.b_.c
 
+Can't have a domain with no letters: mdast-util-gfm-autolink-literal@1.0.1
+
 ## Link text should not be expanded
 
 [Visit www.example.com](http://www.example.com) please.


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

GitHub does not link strings of the format
mdast-util-gfm-autolink-literal@1.0.1 but will link if you add a letter
to the label/domain. Emulate that behavior.

Ref: https://github.com/remarkjs/remark/discussions/862

<!--do not edit: pr-->
