### PR TITLE
fix: limit match length of email regular expression

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -141,7 +141,22 @@ function transformGfmAutolinkLiterals(tree) {
     tree,
     [
       [/(https?:\/\/|www(?=\.))([-.\w]+)([^ \t\r\n]*)/gi, findUrl],
-      [/([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/g, findEmail]
+      // Use limited buffer sizes instead of `+` to avoid pathological regular
+      // expression behavior; see
+      // https://github.com/syntax-tree/mdast-util-gfm-autolink-literal/issues/8
+      //
+      // limits on email addresses:
+      //
+      // In addition to restrictions on syntax, there is a length limit on
+      //    email addresses.  That limit is a maximum of 64 characters (octets)
+      //    in the "local part" (before the "@") and a maximum of 255 characters
+      //    (octets) in the domain part (after the "@") for a total length of 320
+      //    characters. However, there is a restriction in RFC 2821 on the length of an
+      //    address in MAIL and RCPT commands of 254 characters.  Since addresses
+      //    that do not fit in those fields are not normally useful, the upper
+      //    limit on address lengths should normally be considered to be 254.
+      // - http://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690
+      [/([-.\w+]{1,64})@([-\w]{1,255}(?:\.[-\w]{1,255}){1,255})/g, findEmail]
     ],
     {ignore: ['link', 'linkReference']}
   )


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This is a quick fix for the problem described in #8, where a long line causes the `findEmail` regular expression to exhibit pathological behavior.

The solution presented here is to replace every `+` in the regular expression with `{1,255}`; it will still be super-linear on long lines but the buffer is now small enough that the function will complete in an acceptable period of time.

The maximum length of a valid email address is 255 [according to the IETF here](https://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690), but I've left room in the regex for 64 before and 255 after the `@`.

This only improves matters, doesn't fix the problem entirely.

Before this PR, line lenghts of up to about 50,000 cause recursion failure:

<img width="645" alt="image" src="https://github.com/user-attachments/assets/c6837656-60a5-4e6c-8d1c-b2bce55a7e06">

With this PR, I can run the regex on strings of length up to 10 megabytes, which seems like a very comfortable line length, certainly a big improvement:

<img width="645" alt="image" src="https://github.com/user-attachments/assets/86566873-4ce0-44b7-b63e-369b99ae3a58">


but it still fails with a recursion limit above that

closes #8

<!--do not edit: pr-->
