### PR TITLE
add: support for old version of safari version 16 without break thing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -163,6 +163,7 @@ function legacyAutolinkTransform(tree) {
     tree,
     [
       [/(https?:\/\/|www(?=\.))([-.\w]+)([^ \t\r\n]*)/gi, findUrl],
+      // [/([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/g, findEmail] # NOTE: this is your version, we can use your if you want
       [/(^|\s|\p{P}|\p{S})([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu, findEmailLegacy]
     ],
     {ignore: ['link', 'linkReference']}

--- a/lib/index.js
+++ b/lib/index.js
@@ -126,8 +126,24 @@ function exitLiteralAutolink(token) {
   this.exit(token)
 }
 
-/** @type {FromMarkdownTransform} */
-function transformGfmAutolinkLiterals(tree) {
+// Regex support detector
+const regexSupport = {
+  lookbehind: (() => {
+    try {
+      // Using regex literal instead of RegExp constructor
+      ;/(?<=x)/.test('x')
+      return true
+    } catch {
+      return false
+    }
+  })()
+}
+
+/**
+ * Modern version of autolink transform using lookbehind
+ * @type {FromMarkdownTransform}
+ */
+function modernAutolinkTransform(tree) {
   findAndReplace(
     tree,
     [
@@ -136,6 +152,45 @@ function transformGfmAutolinkLiterals(tree) {
     ],
     {ignore: ['link', 'linkReference']}
   )
+}
+
+/**
+ * Legacy version of autolink transform for older Node.js versions
+ * @type {FromMarkdownTransform}
+ */
+function legacyAutolinkTransform(tree) {
+  findAndReplace(
+    tree,
+    [
+      [/(https?:\/\/|www(?=\.))([-.\w]+)([^ \t\r\n]*)/gi, findUrl],
+      [/(^|\s|\p{P}|\p{S})([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu, findEmailLegacy]
+    ],
+    {ignore: ['link', 'linkReference']}
+  )
+}
+
+/**
+ * Helper function for legacy email matching
+ * @param {string} _ - Unused parameter
+ * @param {string} prefix - Email prefix
+ * @param {string} name - Email name
+ * @param {string} domain - Email domain
+ * @returns {*} The processed email
+ */
+function findEmailLegacy(_, prefix, name, domain) {
+  return findEmail(name + '@' + domain)
+}
+
+/**
+ * Main transform function that uses the appropriate version based on regex support
+ * @type {FromMarkdownTransform}
+ */
+function transformGfmAutolinkLiterals(tree) {
+  if (regexSupport.lookbehind) {
+    modernAutolinkTransform(tree)
+  } else {
+    legacyAutolinkTransform(tree)
+  }
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -452,6 +452,15 @@ test('gfmAutolinkLiteralToMarkdown()', async function (t) {
   )
 })
 
+/**
+ * Normalizes line endings to Unix style (\n)
+ * @param {string} text - The text to normalize
+ * @returns {string} The normalized text
+ */
+function normalizeLineEndings(text) {
+  return text.replaceAll('\r\n', '\n')
+}
+
 test('fixtures', async function (t) {
   const root = new URL('fixture/', import.meta.url)
 
@@ -469,8 +478,10 @@ test('fixtures', async function (t) {
       const inputUrl = new URL(file, root)
       const expectedUrl = new URL(stem + '.html', root)
 
-      const input = await fs.readFile(inputUrl)
-      const expected = String(await fs.readFile(expectedUrl))
+      const input = normalizeLineEndings(String(await fs.readFile(inputUrl)))
+      const expected = normalizeLineEndings(
+        String(await fs.readFile(expectedUrl))
+      )
 
       const mdast = fromMarkdown(input, {
         extensions: [gfmAutolinkLiteral()],


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

as we discuss about "negative lookbehind" not working on old version safari in this issue: #10 
I try to update it:
1) fix windows issue while runing on fresh test
2) add a check if current system support:

```
function transformGfmAutolinkLiterals(tree) {
  if (regexSupport.lookbehind) {
    modernAutolinkTransform(tree)
  } else {
    legacyAutolinkTransform(tree)
  }
}
```

the test is simple and running before we do anything else:
```
// Regex support detector
const regexSupport = {
  lookbehind: (() => {
    try {
      // Using regex literal instead of RegExp constructor
      ;/(?<=x)/.test('x')
      return true
    } catch {
      return false
    }
  })()
}
```

the result is fine:

The before change test:
![before](https://github.com/user-attachments/assets/92c4e698-a877-4b6c-8bbb-8a6a356bb9d8)

The after change test:
![after with node 22](https://github.com/user-attachments/assets/3439404f-edde-48ba-ab0b-a97223f396ae)

I also try to install nodejs 16 but it not work, so I realize I cannot use many new syntax since nodejs 16 not support. Then I understand why you want to skip support.

I also try to build, to replace my current code to test on my ios, but the node_modules not found the autolink-literal since it is very deep link. I will try to test futher on ios 16.

I hope you can give me some thought about my idea. I don't mind if it useless and should not be merge, since I'm not have many experience. I would like to here what you think.

Thank you <3


<!--do not edit: pr-->
