### PR TITLE
fix: use iOS-compatible regex for autolink parsing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -132,7 +132,7 @@ function transformGfmAutolinkLiterals(tree) {
     tree,
     [
       [/(https?:\/\/|www(?=\.))([-.\w]+)([^ \t\r\n]*)/gi, findUrl],
-      [/(?<=^|\s|\p{P}|\p{S})([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu, findEmail]
+      [/(?:^|\s|[!"#$%&'()*+,\-./:;<=>?@[\\]^_`{|}~])([-.\\w+]+)@([-\w]+(?:\.[-\w]+)+)/gi, findEmail]
     ],
     {ignore: ['link', 'linkReference']}
   )


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [ ] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [ ] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [ ] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [ ] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [ ] I made sure the docs are up to date
* [ ] I included tests (or that’s not needed)

### Description of changes

修复ios低版本，ios16版本，正则表达式报错问题。
之前的正则，在ios低版本会报错误，[Error] SyntaxError: Invalid regular expression: invalid group specifier name。
该正则表达式包含 Safari 使用的 JavaScript 引擎不支持的语法。这通常涉及较新的功能，如后行断言或命名捕获组 。

<!--do not edit: pr-->
