### PR TITLE
perf: pre-declare position on link/text factories

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,13 @@ export function gfmAutolinkLiteralToMarkdown() {
  * @type {FromMarkdownHandle}
  */
 function enterLiteralAutolink(token) {
-  this.enter({type: 'link', title: null, url: '', children: []}, token)
+  // Trailing `position: undefined` keeps the link hidden class stable;
+  // mdast-util-from-markdown's enter() patches the field to a real value
+  // but the property already exists, so no shape transition fires.
+  this.enter(
+    {type: 'link', title: null, url: '', children: [], position: undefined},
+    token
+  )
 }
 
 /**
@@ -171,16 +177,20 @@ function findUrl(_, protocol, domain, path, match) {
 
   if (!parts[0]) return false
 
+  // Trailing `position: undefined` on every node literal keeps each
+  // link / text hidden class stable; an upstream pass in find-and-replace
+  // patches the field to a real value before the node is observable.
   /** @type {Link} */
   const result = {
     type: 'link',
     title: null,
     url: prefix + protocol + parts[0],
-    children: [{type: 'text', value: protocol + parts[0]}]
+    children: [{type: 'text', value: protocol + parts[0], position: undefined}],
+    position: undefined
   }
 
   if (parts[1]) {
-    return [result, {type: 'text', value: parts[1]}]
+    return [result, {type: 'text', value: parts[1], position: undefined}]
   }
 
   return result
@@ -204,11 +214,13 @@ function findEmail(_, atext, label, match) {
     return false
   }
 
+  // See findUrl above for the rationale on the trailing position field.
   return {
     type: 'link',
     title: null,
     url: 'mailto:' + atext + '@' + label,
-    children: [{type: 'text', value: atext + '@' + label}]
+    children: [{type: 'text', value: atext + '@' + label, position: undefined}],
+    position: undefined
   }
 }
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Problem: this extension builds link nodes (and their nested text
children) in two paths: the enter handler for literal autolinks
during parse, and a post-parse find-and-replace transform that walks
text nodes and produces link/text nodes from URL-shaped substrings.
In both paths the literals are fresh objects with no position field;
position is patched in afterwards. V8 treats the late assignment as
a shape change, so every link and text node walks through two hidden
classes instead of one. Core nodes already avoid this; extension
nodes leave the tree with mixed layouts and tree walks lose
monomorphic dispatch.

Goal: declare position on every link and text literal this extension
produces, both in the enter handler and in the post-parse transform,
so V8 keeps a single hidden class per node type.

Changes:
- lib/index.js: trailing position: undefined on the link literal in
  enterLiteralAutolink.
- lib/index.js: trailing position: undefined on the link and nested
  text literals returned from findUrl, plus the trailing-text node
  when splitUrl strips punctuation.
- lib/index.js: trailing position: undefined on the link and nested
  text literals returned from findEmail.

Notes: the transform-path literals at lines 175 through 180, 183, and
207 through 212 are returned from find-and-replace callbacks rather
than going through this.enter(). A one-off probe (parsing
'visit [www.example.com\n](http://www.example.com/n)' with the GFM extension) confirmed that
something further down the pipeline populates position on these
nodes, so the pre-declared field gets overwritten with a real value
and the test fixtures continue to assert real position objects.
Pairs with the matching core change in
https://github.com/syntax-tree/mdast-util-from-markdown/pull/53;
merged on its own this branch is a no-op. Validated with npm test
(build, format, 100% coverage, 49 of 49 tests in dev and prod).

Bench (local harness, 3-run median-of-medians, GFM tokenizer and
mdast extensions stacked). Numbers below are the parse time delta
versus an unmodified upstream main; positive numbers mean slower,
negative numbers mean faster.

Two scenarios exercise this code path. The first is 5000 bare URLs
interleaved with surrounding text, which is the largest mdast-layer
share in the GFM corpus on the baseline (full 319.6 ms, tokenize-only
142.8 ms; the gap between those is roughly 35 microseconds of
mdast-layer work per URL, mostly node allocation and position
bookkeeping). The second is the syntax-tree GFM-stack readme used as
a real-world fixture, where the autolink resolver walks every text
node.

Effect of pairing this branch with PR #53:

- 5000 bare URLs interleaved with text:
  PR #53 alone: 2.3 percent slower than baseline.
  PR #53 with this branch alongside: 2.5 percent FASTER than baseline.
- syntax-tree GFM-stack readme:
  PR #53 alone: 29.4 percent slower than baseline.
  PR #53 with this branch alongside: 22.5 percent slower than baseline.

The bare-URL scenario is the only configuration across the whole
5-repo paired set where the paired build runs faster than upstream
main: pairing recovers 4.8 percentage points and crosses zero into a
real win. The 6.9-point swing on the readme matches what the V8
hidden-class hypothesis predicts: with link and text literals sharing
the core layout, every link in the resulting tree dispatches through
one inline cache.

The readme's 22.5 percent paired residual sits in the upper end of
the machine's drift band (a separately measured drift floor of main
against itself ran at 4 to 12 percent across most GFM inputs in the
same window), which is consistent with no real regression on top of
the change.

<!--do not edit: pr-->
